### PR TITLE
adding calorie count calculation to the overlay

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="onepeloton.permission.SUBSCRIPTION_TYPE_ACCESS" />
     
     <!-- Bluetooth permissions for BLE FTMS -->
@@ -48,7 +49,12 @@
 
         <service
             android:name=".overlay.OverlayService"
-            android:exported="true" />
+            android:exported="true"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Displays live workout statistics overlay" />
+        </service>
             
         
     </application>

--- a/app/src/main/java/com/spop/poverlay/overlay/OverlayTimerViewModel.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/OverlayTimerViewModel.kt
@@ -3,62 +3,87 @@ package com.spop.poverlay.overlay
 import android.app.Application
 import android.text.format.DateUtils
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import com.spop.poverlay.ConfigurationRepository
 import com.spop.poverlay.util.tickerFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
 open class OverlayTimerViewModel(
     application: Application,
-    private val configurationRepository: ConfigurationRepository
+    private val configurationRepository: ConfigurationRepository,
+    powerFlow: Flow<Float>
 ) : AndroidViewModel(application) {
+    companion object {
+        // Power threshold to consider the user is actively pedaling (in watts)
+        private const val POWER_THRESHOLD = 5f
+    }
+    
     val showTimerWhenMinimized
         get() = configurationRepository.showTimerWhenMinimized
     private val timerEnabled = MutableStateFlow(false)
     private val mutableTimerPaused = MutableStateFlow(false)
     val timerPaused = mutableTimerPaused.asSharedFlow()
-    val timerLabel = timerEnabled.flatMapLatest {
+    
+    // Expose elapsed seconds for calories calculation
+    val elapsedSeconds = timerEnabled.flatMapLatest {
         if (it) {
             tickerFlow(period = 1.seconds)
                 .filter { !mutableTimerPaused.value }
                 .runningFold(0L) { acc, _ -> acc + 1L }
-                .map { seconds ->
-                    DateUtils.formatElapsedTime(seconds)
-                }
         } else {
             flow {
-                emit("‒ ‒:‒ ‒")
+                emit(0L)
+            }
+        }
+    }
+    
+    val timerLabel = elapsedSeconds.map { seconds ->
+        if (timerEnabled.value) {
+            DateUtils.formatElapsedTime(seconds)
+        } else {
+            "‒ ‒:‒ ‒"
+        }
+    }
+    
+    init {
+        // Auto-start/stop timer based on power output
+        viewModelScope.launch(Dispatchers.IO) {
+            powerFlow.collect { power ->
+                if (power > POWER_THRESHOLD) {
+                    // User is pedaling - ensure timer is running
+                    if (!timerEnabled.value) {
+                        timerEnabled.value = true
+                    }
+                    if (mutableTimerPaused.value) {
+                        mutableTimerPaused.value = false
+                    }
+                } else {
+                    // Power is zero - pause the timer
+                    if (timerEnabled.value && !mutableTimerPaused.value) {
+                        mutableTimerPaused.value = true
+                    }
+                }
             }
         }
     }
 
     fun onTimerTap() {
+        // Allow manual pause/resume override
         if (timerEnabled.value) {
-            toggleTimer()
-        } else {
-            resumeTimer()
+            mutableTimerPaused.value = !mutableTimerPaused.value
         }
     }
 
     fun onTimerLongPress() {
-        if (timerEnabled.value) {
-            stopTimer()
-        } else {
-            resumeTimer()
-        }
+        // Long press to reset timer to zero
+        stopTimer()
     }
 
     private fun stopTimer() {
         timerEnabled.value = false
         mutableTimerPaused.value = false
-    }
-
-    private fun resumeTimer() {
-        mutableTimerPaused.value = false
-        timerEnabled.value = true
-    }
-
-    private fun toggleTimer() {
-        mutableTimerPaused.value = !mutableTimerPaused.value
     }
 }

--- a/app/src/main/java/com/spop/poverlay/overlay/composables/Overlay.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/composables/Overlay.kt
@@ -60,6 +60,7 @@ fun Overlay(
     val resistance by sensorViewModel.resistanceValue.collectAsStateWithLifecycle(initialValue = SensorValuePlaceholderText)
     val speed by sensorViewModel.speedValue.collectAsStateWithLifecycle(initialValue = SensorValuePlaceholderText)
     val speedLabel by sensorViewModel.speedLabel.collectAsStateWithLifecycle(initialValue = "")
+    val calories by sensorViewModel.caloriesValue.collectAsStateWithLifecycle(initialValue = SensorValuePlaceholderText)
     val timerLabel by timerViewModel.timerLabel.collectAsStateWithLifecycle(initialValue = "")
     val isTimerPaused by timerViewModel.timerPaused.collectAsStateWithLifecycle(initialValue = false)
     val errorMessage by sensorViewModel.errorMessage.collectAsStateWithLifecycle(initialValue = null)
@@ -192,6 +193,7 @@ fun Overlay(
                 resistance = resistance,
                 speed = speed,
                 speedLabel = speedLabel,
+                calories = calories,
                 onSpeedClicked = { sensorViewModel.onClickedSpeed() },
                 onChartClicked = { sensorViewModel.onOverlayPressed() }
             )

--- a/app/src/main/java/com/spop/poverlay/overlay/composables/OverlayMainContent.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/composables/OverlayMainContent.kt
@@ -26,6 +26,7 @@ fun OverlayMainContent(
     resistance: String,
     speed: String,
     speedLabel: String,
+    calories: String,
     pauseChart : Boolean,
     onSpeedClicked : ()->Unit,
     onChartClicked : ()->Unit
@@ -74,6 +75,8 @@ fun OverlayMainContent(
         StatCard("Speed", speed, speedLabel, statCardModifier.clickable {
             onSpeedClicked()
         })
+
+        StatCard("Calories", calories, "kcal", statCardModifier)
 
     }
 }

--- a/app/src/main/java/com/spop/poverlay/sensor/interfaces/DummySensorInterface.kt
+++ b/app/src/main/java/com/spop/poverlay/sensor/interfaces/DummySensorInterface.kt
@@ -7,16 +7,45 @@ import kotlin.math.sin
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Used to generate fake data on the emulator, creates a sin wave of values
+ * Used to generate fake data on the emulator
+ * Power pattern: Ramps up to 80W, holds for 10s, ramps down, pauses for 10s, repeats
+ * This simulates interval training for testing auto-start/stop timer
  */
 class DummySensorInterface : SensorInterface {
     override val power: Flow<Float>
-        get() = dummyValueFlow(200f)
+        get() = intervalPowerFlow()
     override val cadence: Flow<Float>
         get() = dummyValueFlow(150f)
     override val resistance: Flow<Float>
         get() = dummyValueFlow(110f)
 
+    private fun intervalPowerFlow() = flow {
+        while (true) {
+            // Ramp up: 0 to 80W over 2 seconds
+            for (i in 0..20) {
+                emit(i * 4f)  // 0, 4, 8, 12, ... 80
+                delay(100.milliseconds)
+            }
+            
+            // Hold at 80W for 10 seconds
+            for (i in 0..100) {
+                emit(80f)
+                delay(100.milliseconds)
+            }
+            
+            // Ramp down: 80 to 0W over 2 seconds
+            for (i in 20 downTo 0) {
+                emit(i * 4f)  // 80, 76, 72, ... 0
+                delay(100.milliseconds)
+            }
+            
+            // Rest at 0W for 10 seconds
+            for (i in 0..100) {
+                emit(0f)
+                delay(100.milliseconds)
+            }
+        }
+    }
 
     private fun dummyValueFlow(magnitude : Float) = flow {
         val sineValues = generateSequence(0..360 step 10) { it }.flatten().map {


### PR DESCRIPTION
Two changes in this PR:

1) adding a calorie count stats on the realtime dashboard based on the following formula (chatgpt assisted):
Calories Burned (kcal)≈ Watts×Seconds / 4184×Efficiency
Typical efficiency for cycling is ~20–25%

2) changing the way the timer is run, now it starts and stops based on the above 0 power amount, i.e. once the user peddles and power goes up, we start the timer, and if the user stops peddling, we stop the timer

<img width="814" height="784" alt="Screenshot 2025-10-08 at 7 45 12 PM" src="https://github.com/user-attachments/assets/dd708604-ce9e-4ddd-bfac-7b0a16d56d09" />
