### PR TITLE
Add calories to minimized overlay

### DIFF
--- a/app/src/main/java/com/spop/poverlay/ConfigurationPage.kt
+++ b/app/src/main/java/com/spop/poverlay/ConfigurationPage.kt
@@ -41,6 +41,10 @@ fun ConfigurationPage(viewModel: ConfigurationViewModel) {
                     viewModel.showTimerWhenMinimized.collectAsStateWithLifecycle(
                             initialValue = true
                     )
+            val showCaloriesWhenMinimized by
+                    viewModel.showCaloriesWhenMinimized.collectAsStateWithLifecycle(
+                            initialValue = true
+                    )
             val bleTxEnabled by
                     viewModel.bleTxEnabled.collectAsStateWithLifecycle(initialValue = false)
             val bleFtmsDeviceName by
@@ -50,6 +54,8 @@ fun ConfigurationPage(viewModel: ConfigurationViewModel) {
             StartServicePage(
                     timerShownWhenMinimized,
                     viewModel::onShowTimerWhenMinimizedClicked,
+                    showCaloriesWhenMinimized,
+                    viewModel::onShowCaloriesWhenMinimizedClicked,
                     bleTxEnabled,
                     viewModel::onBleTxEnabledClicked,
                     bleFtmsDeviceName,
@@ -66,6 +72,8 @@ fun ConfigurationPage(viewModel: ConfigurationViewModel) {
 private fun StartServicePage(
         timerShownWhenMinimized: Boolean,
         onTimerShownWhenMinimizedToggled: (Boolean) -> Unit,
+        showCaloriesWhenMinimized: Boolean,
+        onShowCaloriesWhenMinimizedToggled: (Boolean) -> Unit,
         bleTxEnabled: Boolean,
         onBleTxEnabledToggled: (Boolean) -> Unit,
         bleFtmsDeviceName: String,
@@ -111,6 +119,13 @@ private fun StartServicePage(
                 onCheckedChange = onTimerShownWhenMinimizedToggled
         )
     }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Show calories in mini view?", fontSize = 20.sp)
+                Checkbox(
+                        checked = showCaloriesWhenMinimized,
+                        onCheckedChange = onShowCaloriesWhenMinimizedToggled
+                )
+        }
     // BLE FTMS Settings
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(

--- a/app/src/main/java/com/spop/poverlay/ConfigurationRepository.kt
+++ b/app/src/main/java/com/spop/poverlay/ConfigurationRepository.kt
@@ -12,6 +12,7 @@ class ConfigurationRepository(context: Context, lifecycleOwner: LifecycleOwner) 
 
     enum class Preferences(val key: String) {
         ShowTimerWhenMinimized("showTimerWhenMinimized"),
+        ShowCaloriesWhenMinimized("showCaloriesWhenMinimized"),
         BleTxEnabled("bleTxEnabled"),
     BleFtmsDeviceName("bleFtmsDeviceName"),
     SerialNumber("serialNumber")
@@ -26,11 +27,13 @@ class ConfigurationRepository(context: Context, lifecycleOwner: LifecycleOwner) 
     }
 
     private val mutableShowTimerWhenMinimized = MutableStateFlow(true)
+    private val mutableShowCaloriesWhenMinimized = MutableStateFlow(true)
     private val mutableBleTxEnabled = MutableStateFlow(true)
     private val mutableBleFtmsDeviceName = MutableStateFlow("Grupetto FTMS")
     private val mutableSerialNumber = MutableStateFlow("")
 
     val showTimerWhenMinimized = mutableShowTimerWhenMinimized
+    val showCaloriesWhenMinimized = mutableShowCaloriesWhenMinimized
     val bleTxEnabled = mutableBleTxEnabled
     val bleFtmsDeviceName = mutableBleFtmsDeviceName
     val serialNumber = mutableSerialNumber
@@ -66,6 +69,13 @@ class ConfigurationRepository(context: Context, lifecycleOwner: LifecycleOwner) 
         }
     }
 
+    fun setShowCaloriesWhenMinimized(isShown: Boolean) {
+        mutableShowCaloriesWhenMinimized.value = isShown
+        sharedPreferences.edit {
+            putBoolean(Preferences.ShowCaloriesWhenMinimized.key, isShown)
+        }
+    }
+
     fun setBleTxEnabled(enabled: Boolean) {
         mutableBleTxEnabled.value = enabled
         sharedPreferences.edit {
@@ -97,6 +107,10 @@ class ConfigurationRepository(context: Context, lifecycleOwner: LifecycleOwner) 
         mutableShowTimerWhenMinimized.value =
             sharedPreferences
                 .getBoolean(Preferences.ShowTimerWhenMinimized.key, true)
+
+        mutableShowCaloriesWhenMinimized.value =
+            sharedPreferences
+                .getBoolean(Preferences.ShowCaloriesWhenMinimized.key, true)
 
         mutableBleTxEnabled.value =
             sharedPreferences

--- a/app/src/main/java/com/spop/poverlay/ConfigurationViewModel.kt
+++ b/app/src/main/java/com/spop/poverlay/ConfigurationViewModel.kt
@@ -36,6 +36,9 @@ class ConfigurationViewModel(
     val showTimerWhenMinimized
         get() = configurationRepository.showTimerWhenMinimized
 
+    val showCaloriesWhenMinimized
+        get() = configurationRepository.showCaloriesWhenMinimized
+
     val bleTxEnabled
         get() = configurationRepository.bleTxEnabled
 
@@ -61,6 +64,10 @@ class ConfigurationViewModel(
 
     fun onShowTimerWhenMinimizedClicked(isChecked: Boolean) {
         configurationRepository.setShowTimerWhenMinimized(isChecked)
+    }
+
+    fun onShowCaloriesWhenMinimizedClicked(isChecked: Boolean) {
+        configurationRepository.setShowCaloriesWhenMinimized(isChecked)
     }
 
     fun onBleTxEnabledClicked(isChecked: Boolean) {

--- a/app/src/main/java/com/spop/poverlay/overlay/OverlayTimerViewModel.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/OverlayTimerViewModel.kt
@@ -26,6 +26,9 @@ open class OverlayTimerViewModel(
     val showTimerWhenMinimized
         get() = configurationRepository.showTimerWhenMinimized
 
+    val showCaloriesWhenMinimized
+        get() = configurationRepository.showCaloriesWhenMinimized
+
     // Accumulated seconds (persists across pause/resume)
     private var accumulatedSeconds = 0L
     private val mutableAccumulatedSeconds = MutableStateFlow(0L)

--- a/app/src/main/java/com/spop/poverlay/overlay/composables/Overlay.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/composables/Overlay.kt
@@ -156,6 +156,9 @@ fun Overlay(
             cadenceLabel = rpm,
             speedLabel = speed,
             resistanceLabel = resistance,
+            // show calories in mini view when we have a value
+            showCalories = calories != SensorValuePlaceholderText,
+            caloriesLabel = calories,
             onTap = { timerViewModel.onTimerTap() },
             onLongPress = { timerViewModel.onTimerLongPress() },
             onMinimizeToggle = { sensorViewModel.onOverlayPressed() },

--- a/app/src/main/java/com/spop/poverlay/overlay/composables/Overlay.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/composables/Overlay.kt
@@ -156,8 +156,8 @@ fun Overlay(
             cadenceLabel = rpm,
             speedLabel = speed,
             resistanceLabel = resistance,
-            // show calories in mini view when we have a value
-            showCalories = calories != SensorValuePlaceholderText,
+            // show calories in mini view only if user enabled the setting
+            showCalories = timerViewModel.showCaloriesWhenMinimized.value,
             caloriesLabel = calories,
             onTap = { timerViewModel.onTimerTap() },
             onLongPress = { timerViewModel.onTimerLongPress() },

--- a/app/src/main/java/com/spop/poverlay/overlay/composables/OverlayMinimizedContent.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/composables/OverlayMinimizedContent.kt
@@ -41,6 +41,9 @@ fun OverlayMinimizedContent(
     cadenceLabel: String,
     speedLabel: String,
     resistanceLabel: String,
+    // optional additional stats
+    showCalories: Boolean = false,
+    caloriesLabel: String = "",
     contentAlpha: Float,
     timerLabel: String,
     timerPaused: Boolean,
@@ -165,6 +168,14 @@ fun OverlayMinimizedContent(
                 timerLabel = speedLabel,
                 iconDrawable = R.drawable.ic_speed
             )
+            if (showCalories) {
+                Spacer(modifier = Modifier.width(4.dp))
+                OverlayTimerField(
+                    modifier = Modifier.width(62.dp),
+                    timerLabel = caloriesLabel,
+                    iconDrawable = R.drawable.ic_calories
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Hello. 
This PR adds the calories to the mini view using the same icon as the larger view.

I was working on adding a heart rate monitor before christmas. I got a bit sidetracked, but will work on it again. I did have it working, but sometimes it required me to forget and add the monitor a few times before it started working. I'll try to work out the kinks and resubmit.

~Kevin