### PR TITLE
Improve BLE/Overlay lifecycle and permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,6 @@ android {
                     "-opt-in=kotlin.ExperimentalUnsignedTypes",
                     "-opt-in=androidx.compose.animation.ExperimentalAnimationApi",
                     "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                    "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
                     "-opt-in=kotlinx.coroutines.FlowPreview"
             ]
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
@@ -77,8 +78,8 @@
 
         <service
             android:name=".overlay.OverlayService"
-            android:exported="true"
-            android:foregroundServiceType="specialUse">
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice|specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Displays live workout statistics overlay" />

--- a/app/src/main/java/com/spop/poverlay/MainActivity.kt
+++ b/app/src/main/java/com/spop/poverlay/MainActivity.kt
@@ -21,7 +21,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.text.HtmlCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.spop.poverlay.releases.ReleaseChecker
 import com.spop.poverlay.ui.theme.PTONOverlayTheme
 import kotlinx.coroutines.CoroutineScope
@@ -74,8 +76,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-        lifecycleScope.launchWhenResumed {
-            viewModel.onResume()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                viewModel.onResume()
+            }
         }
     }
 

--- a/app/src/main/java/com/spop/poverlay/ble/BleServer.kt
+++ b/app/src/main/java/com/spop/poverlay/ble/BleServer.kt
@@ -9,10 +9,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.os.ParcelUuid
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import com.spop.poverlay.sensor.interfaces.SensorInterface
-import java.util.*
+import java.util.LinkedList
+import java.util.UUID
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
@@ -29,14 +32,10 @@ class SystemTimeProvider : TimeProvider {
     override fun elapsedRealtime() = android.os.SystemClock.elapsedRealtime()
 }
 
-// Listener for sensor data updates
-interface SensorDataListener {
-    fun onSensorDataUpdated(cadence: Float, power: Float, speed: Float, resistance: Float)
-}
-
 // Base class for all BLE services
-abstract class BaseBleService(val server: BleServer) : SensorDataListener {
+abstract class BaseBleService(val server: BleServer) {
     abstract val service: BluetoothGattService
+    abstract fun onSensorDataUpdated(cadence: Float, power: Float, speed: Float, resistance: Float)
     protected val connectedDevices = mutableSetOf<BluetoothDevice>()
 
     fun hasConnectedDevices(): Boolean = connectedDevices.isNotEmpty()
@@ -63,6 +62,7 @@ abstract class BaseBleService(val server: BleServer) : SensorDataListener {
         }
     }
 
+    @Suppress("DEPRECATION")
     open fun onDescriptorWriteRequest(
             device: BluetoothDevice,
             requestId: Int,
@@ -78,6 +78,7 @@ abstract class BaseBleService(val server: BleServer) : SensorDataListener {
         }
     }
 
+    @Suppress("DEPRECATION")
     open fun onDescriptorReadRequest(
             device: BluetoothDevice,
             requestId: Int,
@@ -143,7 +144,7 @@ class BleServer(
     private val bondStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             if (intent?.action == BluetoothDevice.ACTION_BOND_STATE_CHANGED) {
-                val device = intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE)
+                val device = getBluetoothDeviceExtra(intent)
                 val state = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE)
                 val prev = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.BOND_NONE)
                 val name = try {
@@ -154,6 +155,20 @@ class BleServer(
                 Timber.d("Bond state changed: ${device?.address} $name $prev -> $state")
             }
         }
+    }
+
+    private fun getBluetoothDeviceExtra(intent: Intent): BluetoothDevice? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun characteristicValue(characteristic: BluetoothGattCharacteristic): ByteArray {
+        return characteristic.value ?: ByteArray(0)
     }
 
     //ADD OR EDIT SERVICES HERE
@@ -187,6 +202,26 @@ class BleServer(
         }
         advertiser = localAdvertiser
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val hasConnectPermission = ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.BLUETOOTH_CONNECT
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!hasConnectPermission) {
+                Timber.w("Cannot start BLE server: missing BLUETOOTH_CONNECT permission")
+                return
+            }
+        } else {
+            val hasBluetoothPermission = ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.BLUETOOTH
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!hasBluetoothPermission) {
+                Timber.w("Cannot start BLE server: missing BLUETOOTH permission")
+                return
+            }
+        }
+
         try {
             val server = bluetoothManager.openGattServer(context, this)
             if (server == null) {
@@ -208,6 +243,9 @@ class BleServer(
             startWatchdog()
             
             isServerStarted = true
+        } catch (e: SecurityException) {
+            Timber.e(e, "Failed to open GATT server due to missing Bluetooth permission")
+            stop() // Clean up partial initialization
         } catch (e: Exception) {
             Timber.e(e, "Failed to start BLE server")
             stop() // Clean up partial initialization
@@ -279,6 +317,22 @@ class BleServer(
             isAdvertising = false
             lastAdvertisingStartTime = 0L
             lastAdvertisingFailureCode = null
+            
+            // Reset smoothing and CSC state so a restart begins fresh
+            smoothedCadence = null
+            smoothedPower = null
+            smoothedSpeedMph = null
+            smoothedResistance = null
+            cscCrankResidual = 0.0
+            cscWheelResidual = 0.0
+            cscCumulativeWheelRev = 0L
+            cscLastWheelEvtTime = 0
+            cscCumulativeCrankRev = 0
+            cscLastCrankEvtTime = 0
+            
+            synchronized(notificationSubscriptions) {
+                notificationSubscriptions.clear()
+            }
         } catch (e: SecurityException) {
             Timber.e(e, "Missing bluetooth permissions")
         }
@@ -299,7 +353,17 @@ class BleServer(
         }
 
         try {
-            gattServer?.notifyCharacteristicChanged(device, characteristic, confirm)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                gattServer?.notifyCharacteristicChanged(
+                    device,
+                    characteristic,
+                    confirm,
+                    characteristicValue(characteristic)
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                gattServer?.notifyCharacteristicChanged(device, characteristic, confirm)
+            }
         } catch (e: SecurityException) {
             Timber.e(e, "Missing bluetooth permissions")
         }
@@ -656,7 +720,7 @@ class BleServer(
             sendResponse(device, requestId, BluetoothGatt.GATT_FAILURE, offset, null)
             return
         }
-        sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, characteristic.value)
+        sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, characteristicValue(characteristic))
     }
 
     override fun onDescriptorReadRequest(
@@ -680,9 +744,9 @@ class BleServer(
     ) {
         // Convention compliance: Track CCCD state
         if (descriptor.uuid == CLIENT_CHARACTERISTIC_CONFIG && value != null) {
-            val isEnabled = Arrays.equals(value, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) ||
-                           Arrays.equals(value, BluetoothGattDescriptor.ENABLE_INDICATION_VALUE)
-            val isDisable = Arrays.equals(value, BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
+            val isEnabled = value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) ||
+                           value.contentEquals(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE)
+            val isDisabled = value.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
 
             synchronized(notificationSubscriptions) {
                 val deviceAddress = device.address
@@ -690,7 +754,7 @@ class BleServer(
                     val uuidSet = notificationSubscriptions.getOrPut(deviceAddress) { mutableSetOf() }
                     uuidSet.add(descriptor.characteristic.uuid)
                     Timber.d("Notifications enabled for ${descriptor.characteristic.uuid} on $deviceAddress")
-                } else if (isDisable) {
+                } else if (isDisabled) {
                     notificationSubscriptions[deviceAddress]?.remove(descriptor.characteristic.uuid)
                     if (notificationSubscriptions[deviceAddress]?.isEmpty() == true) {
                         notificationSubscriptions.remove(deviceAddress)
@@ -889,7 +953,7 @@ class BleServer(
         // Wheel
         val wheelSizeMeters = 2.127f // 700c x 28, typical
         // speedKmh must be in km/h; convert to m/s for wheel RPM calculation
-        var speedMps = speedKmh?.let { it / 3.6f }
+        val speedMps = speedKmh?.let { it / 3.6f }
         if (speedMps != null && speedMps > 0f) {
 
             val wheelRpm = (speedMps / wheelSizeMeters) * 60f

--- a/app/src/main/java/com/spop/poverlay/ble/DeviceInformationService.kt
+++ b/app/src/main/java/com/spop/poverlay/ble/DeviceInformationService.kt
@@ -2,9 +2,8 @@ package com.spop.poverlay.ble
 import com.spop.poverlay.BuildConfig
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattService
-import android.os.Build
-import android.health.connect.datatypes.Device
 
+@Suppress("DEPRECATION")
 class DeviceInformationService(server: BleServer) : BaseBleService(server) {
 
     override val service =

--- a/app/src/main/java/com/spop/poverlay/overlay/OverlayService.kt
+++ b/app/src/main/java/com/spop/poverlay/overlay/OverlayService.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
-
 package com.spop.poverlay.overlay
 
 import android.app.Notification
@@ -7,6 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.graphics.PixelFormat
 import android.os.Build
@@ -31,7 +30,9 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.spop.poverlay.ConfigurationRepository
+import com.spop.poverlay.GrupettoApplication
 import com.spop.poverlay.MainActivity
 import com.spop.poverlay.R
 
@@ -45,12 +46,13 @@ import com.spop.poverlay.util.IsG700CrossTrainer
 import com.spop.poverlay.util.IsRunningOnPeloton
 import com.spop.poverlay.util.LifecycleEnabledService
 import com.spop.poverlay.util.disableAnimations
-import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.minutes
 import timber.log.Timber
-import java.util.*
 import kotlin.math.roundToInt
 
 
@@ -62,6 +64,9 @@ class OverlayService : LifecycleEnabledService() {
 
 
         private const val OverlayServiceId = 2032
+        private const val OverlayNotificationChannelId = "grupetto_overlay_service"
+        private const val WakeLockTimeoutMs = 15 * 60 * 1000L
+        private const val WakeLockRenewIntervalMs = 10 * 60 * 1000L
 
         val OverlayHeightDp = 110.dp
 
@@ -77,19 +82,28 @@ class OverlayService : LifecycleEnabledService() {
     }
 
     private var wakeLock: PowerManager.WakeLock? = null
+    private var wakeLockRefreshJob: Job? = null
     private var overlayView: View? = null
     private var touchTargetView: View? = null
     private var windowManager: WindowManager? = null
+    private val bleServer by lazy { (application as GrupettoApplication).bleServer }
 
     override fun onCreate() {
         super.onCreate()
-        acquireWakeLock()
+        syncBackgroundExecutionGuards()
         val notification = prepareNotification(NotificationManagerCompat.from(this))
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startForeground(
                 OverlayServiceId, 
                 notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            )
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                OverlayServiceId,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
             )
         } else {
             startForeground(OverlayServiceId, notification)
@@ -104,6 +118,7 @@ class OverlayService : LifecycleEnabledService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Timber.i("overlay service received intent")
+        syncBackgroundExecutionGuards()
         return START_STICKY
     }
 
@@ -173,12 +188,14 @@ class OverlayService : LifecycleEnabledService() {
         })
         
         // Handle watchdog restart trigger
-        lifecycleScope.launchWhenStarted {
-            watchdog.restartTriggered.collect {
-                Timber.w(
-                    "Watchdog triggered restart - no cadence detected for ${watchdogThreshold.inWholeMinutes} minutes"
-                )
-                restartToOverlay()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                watchdog.restartTriggered.collect {
+                    Timber.w(
+                        "Watchdog triggered restart - no cadence detected for ${watchdogThreshold.inWholeMinutes} minutes"
+                    )
+                    restartToOverlay()
+                }
             }
         }
 
@@ -190,15 +207,11 @@ class OverlayService : LifecycleEnabledService() {
         }
 
 
-        val defaultFlags = (LayoutParams.FLAG_NOT_TOUCH_MODAL
-                or LayoutParams.FLAG_NOT_FOCUSABLE
-                or LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-
         val overlayParams = LayoutParams(
             200,
             LayoutParams.WRAP_CONTENT,
             layoutFlag,
-            defaultFlags,
+            DefaultOverlayFlags,
             PixelFormat.TRANSLUCENT
         ).apply {
             disableAnimations()
@@ -250,57 +263,57 @@ class OverlayService : LifecycleEnabledService() {
         //touchTarget.clipChildren = false
         //touchTarget.clipToPadding = false
         //Subscribe to Dialog view model and update views
-        lifecycleScope.launchWhenResumed {
-            combine(
-                dialogViewModel.dialogOrigin,
-                dialogViewModel.dialogGravity,
-                dialogViewModel.partialOverlayFlags,
-                dialogViewModel.touchTargetHeight,
-                dialogViewModel.dialogSizeParams,
-                dialogViewModel.minimizedDialogSizeParams
-            ) { values ->
-                val origin = values[0] as Offset
-                val gravity = values[1] as Int
-                val overlayFlags = values[2] as Int
-                val touchTargetHeight = values[3] as Float
-                val (width, height)  = values[4] as Pair<Int,Int>
-                val (mWidth, mHeight)  = values[5] as Pair<Int,Int>
-                overlayParams.x = origin.x.roundToInt()
-                overlayParams.y = origin.y.roundToInt()
-                overlayParams.flags = DefaultOverlayFlags or overlayFlags
-                overlayParams.gravity = gravity
-                overlayParams.width = width
-                overlayParams.height = if(sensorViewModel.isMinimized.value){
-                    mHeight
-                }else{
-                    height
-                }
-                touchTargetParams.x = origin.x.roundToInt()
-                touchTargetParams.y = origin.y.roundToInt()
-                touchTargetParams.gravity = gravity
-                touchTargetParams.width = mWidth
-                touchTargetParams.height = touchTargetHeight.roundToInt()
-                val currentOverlay = overlayView
-                val currentTouchTarget = touchTargetView
-                if (currentOverlay == null || currentTouchTarget == null) {
-                    Timber.d("Overlay views cleared before update; skipping layout application")
-                    return@combine
-                }
-                currentTouchTarget.visibility = if (touchTargetHeight > 0f){
-                    View.VISIBLE
-                }else{
-                    View.GONE
-                }
-                disableClipOnParents(currentOverlay)
-                wm.updateViewLayout(currentOverlay, overlayParams)
-                wm.updateViewLayout(currentTouchTarget, touchTargetParams)
-            }.collect(object : FlowCollector<Unit> {
-                override suspend fun emit(value: Unit) {}
-            })
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                combine(
+                    dialogViewModel.dialogOrigin,
+                    dialogViewModel.dialogGravity,
+                    dialogViewModel.partialOverlayFlags,
+                    dialogViewModel.touchTargetHeight,
+                    dialogViewModel.dialogSizeParams,
+                    dialogViewModel.minimizedDialogSizeParams
+                ) { values ->
+                    val origin = values[0] as Offset
+                    val gravity = values[1] as Int
+                    val overlayFlags = values[2] as Int
+                    val touchTargetHeight = values[3] as Float
+                    val (width, height)  = values[4] as Pair<Int,Int>
+                    val (mWidth, mHeight)  = values[5] as Pair<Int,Int>
+                    overlayParams.x = origin.x.roundToInt()
+                    overlayParams.y = origin.y.roundToInt()
+                    overlayParams.flags = DefaultOverlayFlags or overlayFlags
+                    overlayParams.gravity = gravity
+                    overlayParams.width = width
+                    overlayParams.height = if(sensorViewModel.isMinimized.value){
+                        mHeight
+                    }else{
+                        height
+                    }
+                    touchTargetParams.x = origin.x.roundToInt()
+                    touchTargetParams.y = origin.y.roundToInt()
+                    touchTargetParams.gravity = gravity
+                    touchTargetParams.width = mWidth
+                    touchTargetParams.height = touchTargetHeight.roundToInt()
+                    val currentOverlay = overlayView
+                    val currentTouchTarget = touchTargetView
+                    if (currentOverlay == null || currentTouchTarget == null) {
+                        Timber.d("Overlay views cleared before update; skipping layout application")
+                        return@combine
+                    }
+                    currentTouchTarget.visibility = if (touchTargetHeight > 0f){
+                        View.VISIBLE
+                    }else{
+                        View.GONE
+                    }
+                    disableClipOnParents(currentOverlay)
+                    wm.updateViewLayout(currentOverlay, overlayParams)
+                    wm.updateViewLayout(currentTouchTarget, touchTargetParams)
+                }.collect {}
+            }
         }
     }
 
-    fun disableClipOnParents(v: View) {
+    private fun disableClipOnParents(v: View) {
         if (v.parent == null) {
             return
         }
@@ -329,7 +342,7 @@ class OverlayService : LifecycleEnabledService() {
     }
 
     private fun prepareNotification(notificationManager: NotificationManagerCompat): Notification {
-        val channelId = UUID.randomUUID().toString()
+        val channelId = OverlayNotificationChannelId
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
             notificationManager.getNotificationChannel(channelId) == null
@@ -366,6 +379,8 @@ class OverlayService : LifecycleEnabledService() {
 
         notificationBuilder
             .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.overlay_notification))
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setOnlyAlertOnce(true)
             .setOngoing(true)
@@ -380,17 +395,75 @@ class OverlayService : LifecycleEnabledService() {
         val pm = ContextCompat.getSystemService(this, PowerManager::class.java) ?: return
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Grupetto:OverlayWakelock").apply {
             setReferenceCounted(false)
-            acquire()
+            acquire(WakeLockTimeoutMs)
+        }
+        wakeLockRefreshJob?.cancel()
+        wakeLockRefreshJob = lifecycleScope.launch {
+            while (isActive) {
+                delay(WakeLockRenewIntervalMs)
+                wakeLock?.let {
+                    if (it.isHeld) {
+                        it.acquire(WakeLockTimeoutMs)
+                    }
+                }
+            }
         }
     }
 
     private fun releaseWakeLock() {
+        wakeLockRefreshJob?.cancel()
+        wakeLockRefreshJob = null
         wakeLock?.let {
             if (it.isHeld) {
                 it.release()
             }
         }
         wakeLock = null
+    }
+
+    private fun syncBackgroundExecutionGuards() {
+        if (isBleTxEnabled() && hasBleRuntimePermissions()) {
+            bleServer.start()
+            acquireWakeLock()
+        } else {
+            releaseWakeLock()
+        }
+    }
+
+    private fun isBleTxEnabled(): Boolean {
+        val prefs = getSharedPreferences(ConfigurationRepository.SharedPrefsName, MODE_PRIVATE)
+        return prefs.getBoolean(ConfigurationRepository.Preferences.BleTxEnabled.key, true)
+    }
+
+    private fun hasBleRuntimePermissions(): Boolean {
+        val hasBaseBluetooth = ContextCompat.checkSelfPermission(
+            this,
+            android.Manifest.permission.BLUETOOTH
+        ) == PackageManager.PERMISSION_GRANTED
+
+        val hasBluetoothAdmin = ContextCompat.checkSelfPermission(
+            this,
+            android.Manifest.permission.BLUETOOTH_ADMIN
+        ) == PackageManager.PERMISSION_GRANTED
+
+        val hasFineLocation = ContextCompat.checkSelfPermission(
+            this,
+            android.Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val hasAdvertise = ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.BLUETOOTH_ADVERTISE
+            ) == PackageManager.PERMISSION_GRANTED
+            val hasConnect = ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.BLUETOOTH_CONNECT
+            ) == PackageManager.PERMISSION_GRANTED
+            return hasBaseBluetooth && hasBluetoothAdmin && hasFineLocation && hasAdvertise && hasConnect
+        }
+
+        return hasBaseBluetooth && hasBluetoothAdmin && hasFineLocation
     }
 
     private fun removeOverlayViews() {

--- a/app/src/main/java/com/spop/poverlay/ui/theme/Theme.kt
+++ b/app/src/main/java/com/spop/poverlay/ui/theme/Theme.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
-import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 
 private val DarkColorPalette = darkColors(
         primary = Purple80,
@@ -25,8 +25,9 @@ fun PTONOverlayTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            (view.context as Activity).window.statusBarColor = colors.primary.toArgb()
-            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
+            val window = (view.context as Activity).window
+            window.statusBarColor = colors.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }
     }
 


### PR DESCRIPTION
Add Android 13+ permission handling and lifecycle fixes for BLE and overlay features. Updates include:

- Manifest: add FOREGROUND_SERVICE_CONNECTED_DEVICE permission and set OverlayService exported=false; set foregroundServiceType to include connectedDevice|specialUse.
- MainActivity/OverlayService: replace launchWhenResumed/launchWhenStarted with lifecycleScope.launch + repeatOnLifecycle to ensure correct lifecycle collection.
- BleServer: robust permission checks for different SDKs (BLUETOOTH_CONNECT vs BLUETOOTH), handle TIRAMISU Parcelable API, provide characteristicValue helper, handle SecurityException during startup/stop, reset smoothing/CSC state on stop, use correct notifyCharacteristicChanged overload, and simplify byte-array comparisons and small API/variable cleanups.
- OverlayService: add wake-lock renewal job with timeout, syncBackgroundExecutionGuards to start/stop BLE based on prefs & permissions, reuse notification channel id (no random UUID), set notification title/text, adjust foreground types per SDK, refactor overlay flags and collection handling, make helpers private, and minor view/update refinements.
- DeviceInformationService: suppress deprecation where needed.
- Theme: switch to WindowCompat.getInsetsController for status bar appearance.
- build.gradle: remove unused opt-in for lifecycle compose.

These changes improve stability across Android versions, ensure proper permission handling, and make lifecycle-driven coroutines and BLE behavior more reliable.