### PR TITLE
Add support for dynamic mac address for bluetooth hrm

### DIFF
--- a/app/src/main/java/com/spop/poverlay/ConfigurationPage.kt
+++ b/app/src/main/java/com/spop/poverlay/ConfigurationPage.kt
@@ -77,6 +77,8 @@ fun ConfigurationPage(viewModel: ConfigurationViewModel) {
                         viewModel.hrSavedDevices.collectAsStateWithLifecycle(initialValue = emptyList())
                 val hrIsScanning by
                         viewModel.hrIsScanning.collectAsStateWithLifecycle(initialValue = false)
+                val hrMatchByName by
+                        viewModel.hrMatchByName.collectAsStateWithLifecycle(initialValue = false)
                 val isOverlayRunning by
                         viewModel.isOverlayRunning.collectAsStateWithLifecycle(initialValue = false)
                 StartServicePage(
@@ -89,11 +91,13 @@ fun ConfigurationPage(viewModel: ConfigurationViewModel) {
                         hrDiscoveredDevices,
                         hrSavedDevices,
                         hrIsScanning,
+                        hrMatchByName,
                         viewModel::startHeartRateDiscovery,
                         viewModel::stopHeartRateDiscovery,
                         viewModel::connectHeartRateDevice,
                         viewModel::disconnectHeartRateDevice,
                         viewModel::forgetHeartRateDevice,
+                        viewModel::setHrMatchByName,
                         isOverlayRunning,
                         uiScale,
                         viewModel::onStartServiceClicked,
@@ -117,11 +121,13 @@ private fun StartServicePage(
         hrDiscoveredDevices: List<HeartRateDevice>,
         hrSavedDevices: List<HeartRateDevice>,
         hrIsScanning: Boolean,
+        hrMatchByName: Boolean,
         onStartHeartRateDiscovery: () -> Unit,
         onStopHeartRateDiscovery: () -> Unit,
         onConnectHeartRateDevice: (HeartRateDevice) -> Unit,
         onDisconnectHeartRateDevice: () -> Unit,
         onForgetHeartRateDevice: (String) -> Unit,
+        onSetHrMatchByName: (Boolean) -> Unit,
         isOverlayRunning: Boolean,
         uiScale: UiScale,
         onClickedStartOverlay: () -> Unit,
@@ -374,11 +380,13 @@ private fun StartServicePage(
                 discoveredDevices = hrDiscoveredDevices,
                 savedDevices = hrSavedDevices,
                 isScanning = hrIsScanning,
+                matchByName = hrMatchByName,
                 onStartDiscovery = onStartHeartRateDiscovery,
                 onStopDiscovery = onStopHeartRateDiscovery,
                 onConnectDevice = onConnectHeartRateDevice,
                 onDisconnectConnectedDevice = onDisconnectHeartRateDevice,
                 onForgetDevice = onForgetHeartRateDevice,
+                onSetMatchByName = onSetHrMatchByName,
                 onDismiss = { showHeartRateDialog = false }
         )
     }
@@ -408,11 +416,13 @@ private fun HeartRateManagerDialog(
                 discoveredDevices: List<HeartRateDevice>,
                 savedDevices: List<HeartRateDevice>,
                 isScanning: Boolean,
+                matchByName: Boolean,
                 onStartDiscovery: () -> Unit,
                 onStopDiscovery: () -> Unit,
                 onConnectDevice: (HeartRateDevice) -> Unit,
                 onDisconnectConnectedDevice: () -> Unit,
                 onForgetDevice: (String) -> Unit,
+                onSetMatchByName: (Boolean) -> Unit,
                 onDismiss: () -> Unit
 ) {
         val zone12 = remember { mutableStateOf("") }
@@ -591,6 +601,40 @@ private fun HeartRateManagerDialog(
                                                         }
                                                 }
                                         }
+                                                }
+                                        }
+
+                                        Divider(modifier = Modifier.padding(vertical = 8.dp), color = bodyColor.copy(alpha = 0.25f))
+
+                                        Card(
+                                                        backgroundColor = Color(0xFF252525),
+                                                        modifier = Modifier.fillMaxWidth()
+                                        ) {
+                                                Column(modifier = Modifier.padding(10.dp)) {
+                                                        SectionHeader("Connection Options")
+                                                        Row(
+                                                                modifier = Modifier.fillMaxWidth(),
+                                                                verticalAlignment = Alignment.CenterVertically,
+                                                                horizontalArrangement = Arrangement.SpaceBetween
+                                                        ) {
+                                                                Column(modifier = Modifier.weight(1f)) {
+                                                                        Text("Match by name only", fontSize = 16.sp, color = headingColor)
+                                                                        Text(
+                                                                                "Reconnect using device name instead of MAC address. Useful when the MAC changes.",
+                                                                                fontSize = 13.sp,
+                                                                                color = bodyColor
+                                                                        )
+                                                                }
+                                                                Spacer(modifier = Modifier.width(8.dp))
+                                                                Switch(
+                                                                        checked = matchByName,
+                                                                        onCheckedChange = onSetMatchByName,
+                                                                        colors = SwitchDefaults.colors(
+                                                                                checkedThumbColor = Color(0xFF22C55E),
+                                                                                checkedTrackColor = Color(0xFF22C55E)
+                                                                        )
+                                                                )
+                                                        }
                                                 }
                                         }
 

--- a/app/src/main/java/com/spop/poverlay/ConfigurationViewModel.kt
+++ b/app/src/main/java/com/spop/poverlay/ConfigurationViewModel.kt
@@ -41,6 +41,7 @@ class ConfigurationViewModel(
     val hrDiscoveredDevices = HeartRateManager.discoveredDevices
     val hrSavedDevices = HeartRateManager.savedDevices
     val hrIsScanning = HeartRateManager.isScanning
+    val hrMatchByName = HeartRateManager.matchByName
     val isOverlayRunning: StateFlow<Boolean> = OverlayService.isRunning
 
     var latestRelease = mutableStateOf<Release?>(null)
@@ -205,6 +206,10 @@ class ConfigurationViewModel(
 
     fun disconnectHeartRateDevice() {
         HeartRateManager.disconnectCurrent()
+    }
+
+    fun setHrMatchByName(enabled: Boolean) {
+        HeartRateManager.setMatchByName(enabled)
     }
 
     fun onResume() {

--- a/app/src/main/java/com/spop/poverlay/sensor/heartrate/HeartRateManager.kt
+++ b/app/src/main/java/com/spop/poverlay/sensor/heartrate/HeartRateManager.kt
@@ -40,6 +40,7 @@ object HeartRateManager {
     private const val PrefZone23 = "hr_zone_23"
     private const val PrefZone34 = "hr_zone_34"
     private const val PrefZone45 = "hr_zone_45"
+    private const val PrefMatchByName = "hr_match_by_name"
 
     private const val ReconnectDelayMs = 3_000L
     private const val AutoReconnectScanMs = 10_000L
@@ -75,6 +76,9 @@ object HeartRateManager {
     private val _heartRateZones = MutableStateFlow<List<Int>?>(null)
     val heartRateZones: StateFlow<List<Int>?> = _heartRateZones
 
+    private val _matchByName = MutableStateFlow(false)
+    val matchByName: StateFlow<Boolean> = _matchByName
+
     @Volatile
     private var bluetoothGatt: BluetoothGatt? = null
 
@@ -108,6 +112,7 @@ object HeartRateManager {
             appContext = context.applicationContext
             prefs = appContext?.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
             loadHeartRateZones()
+            _matchByName.value = prefs?.getBoolean(PrefMatchByName, false) ?: false
             stopped.set(false)
             loadSavedDevices()
             selectedAddress = prefs?.getString(PrefSelectedDevice, null)
@@ -162,6 +167,11 @@ object HeartRateManager {
         _zone34.value = zone34
         _zone45.value = zone45
         updateHeartRateZones()
+    }
+
+    fun setMatchByName(enabled: Boolean) {
+        _matchByName.value = enabled
+        prefs?.edit { putBoolean(PrefMatchByName, enabled) }
     }
 
     private fun updateHeartRateZones() {
@@ -318,11 +328,46 @@ object HeartRateManager {
         if (manualDisconnectRequested) return false
         if (_connectedDevice.value != null) return false
         val address = device.address ?: return false
-        if (_savedDevices.value.none { it.address == address }) return false
-        selectedAddress = address
-        connectToAddress(address)
-        stopDiscovery()
-        return true
+
+        // Exact MAC match
+        if (_savedDevices.value.any { it.address == address }) {
+            selectedAddress = address
+            connectToAddress(address)
+            stopDiscovery()
+            return true
+        }
+
+        // Name-only match (handles randomized/changed MAC addresses)
+        if (_matchByName.value) {
+            val deviceName = device.name?.takeIf { it.isNotBlank() } ?: return false
+            val matched = _savedDevices.value.firstOrNull {
+                !it.name.isNullOrBlank() && it.name == deviceName
+            } ?: return false
+            updateSavedDeviceAddress(oldAddress = matched.address, newAddress = address, name = deviceName)
+            selectedAddress = address
+            connectToAddress(address)
+            stopDiscovery()
+            return true
+        }
+
+        return false
+    }
+
+    private fun updateSavedDeviceAddress(oldAddress: String, newAddress: String, name: String) {
+        val p = prefs ?: return
+        val saved = p.getStringSet(PrefSavedDevices, emptySet()).orEmpty().toMutableSet()
+        saved.remove(oldAddress)
+        saved.add(newAddress)
+        val wasSelected = p.getString(PrefSelectedDevice, null) == oldAddress
+        p.edit {
+            putStringSet(PrefSavedDevices, saved)
+            remove(PrefNamePrefix + oldAddress)
+            putString(PrefNamePrefix + newAddress, name)
+            if (wasSelected) putString(PrefSelectedDevice, newAddress)
+        }
+        Timber.i("HR device name-matched '%s': updated address %s → %s", name, oldAddress, newAddress)
+        loadSavedDevices()
+        pruneDiscovered()
     }
 
     private fun pruneDiscovered() {


### PR DESCRIPTION
in some cases, the mac address of the hrm changes (e.g. wear os devices that export hrm via bluetooth), because wearos likes to randomize the mac address on each startup for security reasons.  This adds a toggle to allow name based only match, so that if you remember a previously paired bluetooth hrm, and turn on the toggle, a name match is enough to connect. 