### PR TITLE
Update FitnessMachineService.kt

### DIFF
--- a/app/src/main/java/com/spop/poverlay/ble/FitnessMachineService.kt
+++ b/app/src/main/java/com/spop/poverlay/ble/FitnessMachineService.kt
@@ -179,7 +179,8 @@ class FitnessMachineService(server: BleServer) : BaseBleService(server) {
         FitnessMachineConstants.IndoorBikeDataFlags.InstantaneousPowerPresent or
         FitnessMachineConstants.IndoorBikeDataFlags.ResistanceLevelPresent
 
-        val speedValue = (speed * 100).toInt()
+        val speedKmh = speed * 1.60934f // fixes the Issue #30 in the doudar fork of grupetto
+        val speedValue = (speedKmh * 100).toInt() // fixes the Issue #30 in the doudar fork of grupetto
         val cadenceValue = (cadence * 2).toInt()
         val powerValue = power.toInt()
         val resistanceValue = resistance.toInt()


### PR DESCRIPTION
Per: https://github.com/doudar/grupetto/issues/30#issuecomment-4587191951

This fixes the Issue #30 in the doudar fork of grupetto: groupetto sends MPH as KPH to FTMS Devices. Some devices are smart enough to figure out it's wrong, some aren't. Originally proposed by cookebbs.